### PR TITLE
Replace sponsor placeholders with Google AdSense

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Build environment: "production" enables the analytics + AdSense loaders
+# (see src/hooks.server.ts). Anything else disables them for local dev.
+PUBLIC_BUILD_ENV=development
+
+# Google AdSense publisher ID (ca-pub-XXXXXXXXXXXXXXXX).
+# Replace with your real publisher ID once your AdSense account + site are approved.
+PUBLIC_ADSENSE_CLIENT=ca-pub-0000000000000000

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -12,6 +12,11 @@ declare global {
     // interface PageData {}
     // interface Platform {}
   }
+
+  // Google AdSense global injected by the adsbygoogle.js loader
+  interface Window {
+    adsbygoogle?: unknown[]
+  }
 }
 
 export {}

--- a/src/app.html
+++ b/src/app.html
@@ -20,6 +20,7 @@
       src="https://analytics.mark3labs.com/js/script.js"
     ></script>
     %sveltekit.head%
+    <!-- Google AdSense loader injected in production only (see src/hooks.server.ts) -->
   </head>
   <body data-sveltekit-preload-data="hover">
     <div style="display: contents">%sveltekit.body%</div>

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -7,14 +7,26 @@ export const handle = (async ({ resolve, event }) => {
 
   const response = await resolve(event, {
     transformPageChunk: ({ html }) => {
-      // Only include analytics script in production builds
+      // Only include analytics + AdSense scripts in production builds
       const isProduction = env.PUBLIC_BUILD_ENV === 'production'
 
       if (!isProduction) {
-        // Remove the analytics script if not in production
+        // Remove the analytics script if not in production.
+        // The AdSense loader is intentionally NOT injected in non-production to
+        // avoid Google flagging dev/staging traffic as invalid activity.
         return html.replace(
           '<script defer data-domain="louper.dev" src="https://analytics.mark3labs.com/js/script.js"></script>',
           '<!-- Analytics disabled for non-production -->',
+        )
+      }
+
+      // Production: inject the Google AdSense loader using the publisher ID
+      // from PUBLIC_ADSENSE_CLIENT (set in your deployment environment / .env).
+      const adsenseClient = env.PUBLIC_ADSENSE_CLIENT
+      if (adsenseClient) {
+        return html.replace(
+          '</head>',
+          `\t<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=${adsenseClient}" crossorigin="anonymous"></script>\n  </head>`,
         )
       }
 

--- a/src/lib/components/AdSlot.svelte
+++ b/src/lib/components/AdSlot.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { env } from '$env/dynamic/public'
+
+  // Reusable Google AdSense ad unit.
+  //
+  // The publisher ID (ca-pub-XXXXXXXXXXXXXXXX) comes from the PUBLIC_ADSENSE_CLIENT
+  // env var. The adsbygoogle.js loader is injected in production only (see
+  // src/hooks.server.ts), so in dev/staging this renders an empty reserved box and
+  // the push() call is a harmless no-op (window.adsbygoogle is undefined).
+  let {
+    slot,
+    format = 'auto',
+    fullWidthResponsive = true,
+    className = '',
+  }: {
+    slot: string
+    format?: string
+    fullWidthResponsive?: boolean
+    className?: string
+  } = $props()
+
+  onMount(() => {
+    // onMount only runs in the browser, so this never executes during SSR.
+    try {
+      window.adsbygoogle = window.adsbygoogle || []
+      window.adsbygoogle.push({})
+    } catch (e) {
+      console.error('AdSense push failed:', e)
+    }
+  })
+</script>
+
+<div class="flex flex-col {className}">
+  <span class="mb-1 text-xs uppercase tracking-wide text-muted-foreground/60"> Advertisement </span>
+  <ins
+    class="adsbygoogle block min-h-[120px]"
+    style="display:block"
+    data-ad-client={env.PUBLIC_ADSENSE_CLIENT}
+    data-ad-slot={slot}
+    data-ad-format={format}
+    data-full-width-responsive={fullWidthResponsive ? 'true' : 'false'}
+  ></ins>
+</div>

--- a/src/routes/SponsorSlots.svelte
+++ b/src/routes/SponsorSlots.svelte
@@ -1,88 +1,21 @@
 <script lang="ts">
-  // Sponsor data structure for advertisement slots
-  interface Sponsor {
-    name: string
-    description: string
-    logo: string
-    type: 'paid' | 'placeholder'
-  }
+  import AdSlot from '$lib/components/AdSlot.svelte'
 
-  // Static sponsor data array - UPDATE THIS TO CHANGE SPONSOR CONTENT
-  // To update a sponsor: replace name, description, and logo path
-  // Logo images should be placed in /static/img/ directory
-  // Example: logo: '/img/quicknode-logo.svg'
-  const sponsors: Sponsor[] = [
-    // {
-    //   name: 'Sponsor Slot 1',
-    //   description:
-    //     'This is a placeholder for sponsor content. Update this entry with actual sponsor information including name, description, and logo path.',
-    //   logo: '/img/sponsor-placeholder.png',
-    // },
-  ]
-
-  // Fallback image path
-  const FALLBACK_LOGO = '/img/sponsor-placeholder.png'
-
-  // Placeholder sponsor configuration
-  const PLACEHOLDER_SPONSOR: Sponsor = {
-    name: 'Advertise on Louper',
-    description: 'Reach thousands of smart contract developers daily',
-    logo: '/img/sponsor-placeholder.png',
-    type: 'placeholder',
-  }
-
-  // Minimum number of slots to display
-  const MIN_SLOTS = 3
-
-  // Fill sponsors array with placeholders if needed
-  const displaySponsors = [
-    ...sponsors,
-    ...Array(Math.max(0, MIN_SLOTS - sponsors.length)).fill(PLACEHOLDER_SPONSOR),
+  // Google AdSense slot configuration.
+  //
+  // UPDATE the `slot` values below with real AdSense unit IDs (the
+  // data-ad-slot number) created in your AdSense dashboard. The publisher ID
+  // (ca-pub-...) is provided via the PUBLIC_ADSENSE_CLIENT env var and the
+  // adsbygoogle.js loader is injected in production by src/hooks.server.ts.
+  //
+  // Add more entries to render additional ad units on the page.
+  const adSlots: { slot: string; className?: string }[] = [
+    { slot: '0000000000' }, // placeholder - replace with a real AdSense unit ID
   ]
 </script>
 
-<div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3 mb-8">
-  {#each displaySponsors as sponsor, i (i)}
-    <div class="rounded-lg border bg-card text-card-foreground shadow-sm">
-      <div class="p-6 flex flex-row gap-4">
-        <!-- Logo container with 1:1 aspect ratio -->
-        <div class="flex-shrink-0 w-24 h-24">
-          <div class="aspect-square overflow-hidden rounded-lg">
-            <img
-              src={sponsor.logo}
-              alt={sponsor.name}
-              class="size-full object-cover object-center"
-              loading="lazy"
-              onerror={(e) => {
-                const target = e.currentTarget as HTMLImageElement
-                if (target.src !== FALLBACK_LOGO) {
-                  console.error(`Failed to load logo for sponsor: ${sponsor.name}`)
-                  target.src = FALLBACK_LOGO
-                }
-              }}
-            />
-          </div>
-        </div>
-
-        <!-- Text content -->
-        <div class="flex-1 min-w-0">
-          <h3 class="text-xl font-bold mb-2">{sponsor.name}</h3>
-          <p class="line-clamp-3 text-sm text-muted-foreground">
-            {sponsor.description}
-          </p>
-          {#if sponsor.type == 'placeholder'}
-            <div class="mt-2">
-              <a
-                href="https://buy.stripe.com/9B614naaddvIdO862HaVa04"
-                target="_blank"
-                class="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2"
-              >
-                Purchase Now
-              </a>
-            </div>
-          {/if}
-        </div>
-      </div>
-    </div>
+<div class="grid gap-4 mb-8">
+  {#each adSlots as ad, i (i)}
+    <AdSlot slot={ad.slot} className={ad.className} />
   {/each}
 </div>


### PR DESCRIPTION
## Summary

Replaces the "Advertise on Louper" sponsor/placeholder cards with Google AdSense ad units. The AdSense loader is gated to **production only** to avoid Google flagging dev/staging traffic as invalid activity (mirrors the existing analytics gating in `hooks.server.ts`).

## Changes

| File | Change |
|---|---|
| `src/lib/components/AdSlot.svelte` | **New** — reusable AdSense unit. SSR-safe `adsbygoogle.push({})` in `onMount`, reserved `min-h-[120px]` to prevent layout shift, "Advertisement" label |
| `src/routes/SponsorSlots.svelte` | Rewritten to render `<AdSlot>` instances from a config array (sponsor cards + Stripe CTA removed) |
| `src/hooks.server.ts` | Injects `adsbygoogle.js` into `<head>` **in production only**, reading `PUBLIC_ADSENSE_CLIENT` from env |
| `src/app.html` | Comment marker documenting the injection point |
| `src/app.d.ts` | Added `Window.adsbygoogle` global typing |
| `.env.example` | Documents `PUBLIC_BUILD_ENV` and `PUBLIC_ADSENSE_CLIENT` |

## How it behaves
- **Dev/staging:** `adsbygoogle.js` is **not** loaded. The ad slot renders as an empty reserved box; the `push({})` is a harmless no-op. No traffic sent to Google.
- **Production:** Loader script injected with the publisher ID; `onMount` pushes each unit to render real ads.

## Before going live (config)
1. Set in the deployment environment:
   ```
   PUBLIC_BUILD_ENV=production
   PUBLIC_ADSENSE_CLIENT=ca-pub-XXXXXXXXXXXXXXXX
   ```
2. Replace the placeholder `slot: '0000000000'` in `src/routes/SponsorSlots.svelte` with a real `data-ad-slot` unit ID from the AdSense dashboard. Add more entries for additional units.
3. AdSense account must be approved and `louper.dev` verified before real ads serve.

## Verification
- `bun run check` — 0 errors (7 pre-existing warnings in unrelated files)
- `bun run lint` — 0 errors (pre-existing `any` warnings in unrelated files)
- Browser-tested in both dev mode (loader absent, `<ins>` renders with correct `data-ad-client` + reserved height + label, no console errors) and prod-env mode (loader injected into `<head>` matching the AdSense snippet exactly, `window.adsbygoogle` global created, `push({})` registered the unit)

## Notes
- ⚠️ AdSense sets cookies — the existing "privacy friendly analytics" note no longer covers ads; consider updating the privacy policy.
- `static/img/sponsor-placeholder.png` is now unused (left in place, safe to delete).